### PR TITLE
Add Arc type support

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -27,30 +27,36 @@
 ///
 /// ```
 /// use std::rc::Rc;
+/// use std::sync::Arc;
 /// use clone_cell::{cell::Cell, clone::PureClone};
 ///
 /// // Note: This also generates a `Clone` impl.
 /// #[derive(PureClone)]
 /// struct Foo<T> {
 ///     p: Rc<T>, // `Rc<T>` is always `PureClone`.
+///     ap: Arc<T>, // `Arc<T>` is always `PureClone`.
 ///     t: Option<T>, // `Option<T>` is `PureClone` if `T` is.
 ///     x: i32, // `i32` is `PureClone`.
 /// }
 ///
 /// let p = Rc::new(-42);
+/// let ap = Arc::new(-42);
 /// let f = Cell::new(Foo {
 ///     p: p.clone(),
+///     ap: ap.clone(),
 ///     t: Some(0),
 ///     x: 0,
 /// });
 ///
 /// f.set(Foo {
 ///     p,
+///     ap,
 ///     t: Some(42),
 ///     x: 21,
 /// });
 ///
 /// assert_eq!(*f.get().p, -42);
+/// assert_eq!(*f.get().ap, -42);
 /// assert_eq!(f.get().t, Some(42));
 /// assert_eq!(f.get().x, 21);
 /// ```
@@ -73,6 +79,7 @@ mod impls {
     use alloc::{
         boxed::Box,
         rc::{Rc, Weak},
+        sync::{Arc, Weak as SyncWeak},
         vec::Vec,
     };
 
@@ -121,6 +128,7 @@ mod impls {
 
     impl_pure_clone_rc! {
         Rc<T> Weak<T>
+        Arc<T> SyncWeak<T>
     }
 
     impl_pure_clone_generic! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,10 @@
 //!
 //! # Background
 //!
-//! To enable interiorly mutating methods on a type stored in an [`Rc`](alloc::rc::Rc) without the
-//! overhead of a [`RefCell`](core::cell::RefCell), we can wrap each of its fields in a
-//! [`core::cell::Cell`]. But `Cell`'s [`get`](core::cell::Cell::get) method is only implemented for
+//! To enable interiorly mutating methods on a type stored in an [`Rc`](alloc::rc::Rc) or
+//! [`Arc`](alloc::sync::Arc) without the overhead of a [`RefCell`](core::cell::RefCell),
+//! we can wrap each of its fields in a [`core::cell::Cell`].
+//! But `Cell`'s [`get`](core::cell::Cell::get) method is only implemented for
 //! types that are `Copy`. This is because if the `clone` method obtains a reference to the
 //! containing `Cell`, it may be able to mutate its state. This can cause undefined behavior, as
 //! demonstrated in this [example].

--- a/tests/cell_tests.rs
+++ b/tests/cell_tests.rs
@@ -1,4 +1,5 @@
 use std::rc::{Rc, Weak};
+use std::sync::Arc;
 
 use clone_cell::cell::Cell;
 
@@ -36,6 +37,27 @@ fn pure_clone_fields() {
     assert_eq!(*f.x.get(), 42);
     assert_eq!(*f.y.get().unwrap(), 42);
     f.x.set(Rc::new(0));
+    assert_eq!(*f.x.get(), 0);
+    assert_eq!(*f.y.get().unwrap(), 42);
+}
+
+#[test]
+fn pure_clone_fields_arc() {
+    struct Foo {
+        x: Cell<Arc<i32>>,
+        y: Cell<Option<Arc<i32>>>,
+    }
+
+    let f = Rc::new(Foo {
+        x: Cell::new(Arc::new(0)),
+        y: Cell::new(None),
+    });
+    let i = Arc::new(42);
+    f.x.set(i.clone());
+    f.y.set(Some(i));
+    assert_eq!(*f.x.get(), 42);
+    assert_eq!(*f.y.get().unwrap(), 42);
+    f.x.set(Arc::new(0));
     assert_eq!(*f.x.get(), 0);
     assert_eq!(*f.y.get().unwrap(), 42);
 }

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "derive")]
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use clone_cell::{cell::Cell, clone::PureClone};
 
@@ -73,6 +74,7 @@ fn type_params() {
         t: Rc<T>,
         foo: Rc<Foo>,
         bar: Bar<U>,
+        foobar: Arc<Bar<U>>,
     }
 
     let bar = Bar { t: 42 };
@@ -80,10 +82,12 @@ fn type_params() {
         t: Rc::new(Foo),
         foo: Rc::new(Foo),
         bar,
+        foobar: Arc::new(Bar { t: 43 })
     };
     assert_eq!(*baz.pure_clone().t, Foo);
     assert_eq!(*baz.pure_clone().foo, Foo);
     assert_eq!(baz.pure_clone().bar.t, 42);
+    assert_eq!(baz.pure_clone().foobar.t, 43);
 }
 
 #[test]


### PR DESCRIPTION
Hey, thanks for this crate! :) This PR adds support for `std::sync::Arc` and `std::sync::Weak` for symmetry with `std::rc::Rc` and `std::rc::Weak`.